### PR TITLE
#159951962 Implement validations for signup endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://www.travis-ci.org/andela/ah-backend-tesseract.svg?branch=develop)](https://www.travis-ci.org/andela/ah-backend-tesseract)
-[![Coverage Status](https://coveralls.io/repos/github/andela/ah-backend-tesseract/badge.svg?branch=Ch-integrate-test-coverage-159951960)](https://coveralls.io/github/andela/ah-backend-tesseract?branch=Ch-integrate-test-coverage-159951960)
-
+[![Coverage Status](https://coveralls.io/repos/github/andela/ah-backend-tesseract/badge.svg?branch=develop)](https://coveralls.io/github/andela/ah-backend-tesseract?branch=develop)
+[![Maintainability](https://api.codeclimate.com/v1/badges/4f7fed9c6af80aaf6360/maintainability)](https://codeclimate.com/github/andela/ah-backend-tesseract/maintainability)
 Authors Haven - A Social platform for the creative at heart.
 =======
 

--- a/authors/apps/authentication/tests/__init__.py
+++ b/authors/apps/authentication/tests/__init__.py
@@ -1,0 +1,39 @@
+from ..models import User
+from rest_framework.test import APIClient
+from django.test import TestCase
+
+
+class BaseTest(TestCase):
+
+    def setUp(self):
+        self.user_data = {"user": {"username": "Jacob1",
+                                   "email": "jake@jakeg.jake",
+                                   "password": "jakejakeh1"}
+                          }
+
+        self.login_data_email = {"user": {"email": "jake@jakeg.jake",
+                                          "password": "jakejakeh1"}
+                                 }
+
+        self.unregistered_user_data = {"user": {"email": "jake@hhd.jake",
+                                                "password": "jakeakeh1"}
+                                       }
+
+        self.user_validate_data = {"user": {"username": "llll",
+                                            "email": "l@gmail.com",
+                                            "password": "p1234567"
+                                            }
+                                   }
+
+        User.objects.create_user("user_test", "mail@me.com", password="p12345678")
+        self.user_update_data = {"user": {"username": "user_test2",
+                                          "email": "mail@me.com",
+                                          "password": "p12345678"
+                                          }}
+
+        self.user = User.objects.get(email="mail@me.com")
+        self.client = APIClient()
+        self.register_response = self.client.post("/api/users/", self.user_data, format="json")
+        self.login_response = self.client.post("/api/users/login/", self.login_data_email, format="json")
+        token = self.login_response.data["token"]
+        self.client.credentials(HTTP_AUTHORIZATION=token)

--- a/authors/apps/authentication/tests/test_authentication.py
+++ b/authors/apps/authentication/tests/test_authentication.py
@@ -1,38 +1,9 @@
-import jwt
-from django.test import TestCase
-from rest_framework.test import APIClient
 from rest_framework import status
 
-from authors.settings import SECRET_KEY
-
-from .models import User
+from . import BaseTest
 
 
-class BaseTest:
-    def __init__(self):
-        self.user_data = {"user":
-                              {"username": "Jacob1", "email": "jake@jakeg.jake", "password": "jakejakeh"}
-                          }
-
-        self.login_data_email = {"user":
-                                     {"email": "jake@jakeg.jake", "password": "jakejakeh"}
-                                 }
-        self.unregistered_user_data = {"user":
-                                           {"email": "jake@hhd.jake", "password": "jakeakeh"}
-                                       }
-
-
-class AuthenticationTests(TestCase, BaseTest):
-
-    def setUp(self):
-        BaseTest.__init__(self)
-        User.objects.create_user("user_test", "mail@me.com", password="1234")
-        self.user = User.objects.get(email="mail@me.com")
-        self.client = APIClient()
-        self.register_response = self.client.post("/api/users/", self.user_data, format="json")
-        self.login_response = self.client.post("/api/users/login/", self.login_data_email, format="json")
-        token = self.login_response.data["token"]
-        self.client.credentials(HTTP_AUTHORIZATION=token)
+class AuthenticationTests(BaseTest):
 
     def test_username_label(self):
         field_label = self.user._meta.get_field('username').verbose_name
@@ -50,6 +21,11 @@ class AuthenticationTests(TestCase, BaseTest):
     def test_user_registration(self):
         self.assertEqual(self.register_response.status_code, status.HTTP_201_CREATED)
 
+    def test_user_update(self):
+        """Test if a user can update his username"""
+        response = self.client.put("/api/user/", self.user_validate_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_user_login_with_email(self):
         self.assertEqual(self.login_response.status_code, status.HTTP_200_OK)
 
@@ -59,10 +35,6 @@ class AuthenticationTests(TestCase, BaseTest):
 
     def test_user_response_on_register(self):
         response = self.register_response
-        self.assertEqual(len(response.data["token"]) > 2, True)
-
-    def test_user_response_on_login(self):
-        response = self.login_response
         self.assertEqual(len(response.data["token"]) > 2, True)
 
     def test_no_token_provided(self):
@@ -78,4 +50,3 @@ class AuthenticationTests(TestCase, BaseTest):
     def test_user_retrieve(self):
         response = self.client.get("/api/user/", format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-

--- a/authors/apps/authentication/tests/test_validation.py
+++ b/authors/apps/authentication/tests/test_validation.py
@@ -1,0 +1,83 @@
+from rest_framework import status
+
+from . import BaseTest
+
+
+class ValidationTests(BaseTest):
+
+    def test_missing_email(self):
+        """Test whether an error is returned when some required fields are missing"""
+        self.user_validate_data["user"].pop("email")
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["email"],
+                         ["This field is required."])
+
+    def test_missing_username(self):
+        """Test whether an error is returned when some required fields are missing"""
+        self.user_validate_data["user"].pop("username")
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["username"],
+                         ["This field is required."])
+
+    def test_missing_password(self):
+        """Test whether an error is returned when some required fields are missing"""
+        self.user_validate_data["user"].pop("password")
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["password"],
+                         ["This field is required."])
+
+    def test_invalid_username_length(self):
+        """Test whether an error is returned when a short username is provided"""
+        self.user_validate_data["user"]["username"] = "lll"
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["error"],
+                         ['The username should be at least 4 characters long'])
+
+    def test_username_invalid_chars(self):
+        """Test whether an error is returned when invalid characters are in the username"""
+        self.user_validate_data["user"]["username"] = "ll@l"
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["error"],
+                         ['Username should only contain letters, numbers, underscores and hyphens'])
+
+    def test_invalid_email(self):
+        """Test whether an error is returned if the email is in a wrong format"""
+        self.user_validate_data["user"]["email"] = "llll"
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["email"],
+                         ['Enter a valid email address.'])
+
+    def test_short_password(self):
+        """Test whether an error is returned when a short password is used to sign up"""
+        self.user_validate_data["user"]["password"] = "p123"
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["password"],
+                         ['Ensure this field has at least 8 characters.'])
+
+    def test_password_no_digits(self):
+        self.user_validate_data["user"]["password"] = "adakfndlnk"
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["error"],
+                         ['Weak password. The password should contain at least one digit'])
+
+    def test_password_no_chars(self):
+        self.user_validate_data["user"]["password"] = "12345678"
+
+        data = self._helper()
+        self.assertEqual(data["errors"]["error"],
+                         ['Weak password. The password should contain at least one character'])
+
+    def _helper(self):
+        """This sends the request to the api and checks if the errors key exists"""
+        response = self.client.post("/api/users/", self.user_validate_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("errors", response.data)
+        return response.data


### PR DESCRIPTION
#### What does this PR do?
Have validations for sign up endpoint working

#### Description of Task to be completed?
Have the signup endpoint `http://127.0.0.1:8000/api/users/` return descriptive error messages when a user provides invalid data.

#### How should this be manually tested?
Go to postman and try supplying the  following invalid data to the `https://ah-backend-tesseract-sta-pr-11.herokuapp.com/api/users/` endpoint:
```
- Leave out some fields in the request
- Input an invalid username. (A username is one which has  more than 4 characters and only has letters, numbers underscores and hyphens)
- Input an invalid password (A valid password has both numbers and characters)
- Input an invalid email
```

#### What are the relevant pivotal tracker stories?
#159951962