### PR TITLE
#159951974 Implement searching and filtering based on parameters

### DIFF
--- a/authors/apps/articles/tests/test_search.py
+++ b/authors/apps/articles/tests/test_search.py
@@ -1,0 +1,46 @@
+from rest_framework import status
+from . import BaseTest
+from rest_framework.test import APIClient
+
+class SearchArticleTests(BaseTest):
+
+    def test_search_article_by_author(self):
+        response = self.client.get("/api/articles/search/?search=Jacob1234",  format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("Jacob1234", str(response.data))
+
+    def test_search_article_by_title(self):
+        response = self.client.get("/api/articles/search/?search=this is my title", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("this is my title", str(response.data))
+
+
+    def test_filter_article_by_author(self):
+        response = self.client.get("/api/articles/search/?author=Jacob1234",  format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("Jacob1234", str(response.data))
+
+    def test_filter_article_by_not_author(self):
+        response = self.client.get("/api/articles/search/?author=1234notin", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([], response.data)
+
+    def test_filter_article_by_title(self):
+        response = self.client.get("/api/articles/search/?title=this is my title", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("this is my title", str(response.data))
+
+    def test_an_unauthenticated_user_can_filter_by_author(self):
+        self.client = APIClient()
+        response = self.client.get("/api/articles/search/?author=fgftfgf",  format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([], response.data)
+
+    def test_filter_article_by_a_non_existing_tag(self):
+        response = self.client.get("/api/articles/search/?tag=XXXXXXXXXX",  format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([], response.data)
+
+    def test_filter_article_by_tag(self):
+        response = self.client.get("/api/articles/search/?tag=Kampala", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -7,7 +7,9 @@ from .views import (ArticleAPIView,
                     CommentAPIView,
                     ReportArticleAPIView,
                     FavoriteArticleAPIView,
-                    TagListAPIView)
+                    TagListAPIView,
+                    searchArticlesListAPIView
+                    )
 
 
 urlpatterns = [
@@ -27,6 +29,6 @@ urlpatterns = [
          name="get_all_replies"),
     path("article/favorite", FavoriteArticleAPIView.as_view(), name="favorite_article"),
     path("article/<str:slug>/report", ReportArticleAPIView.as_view(), name="report_article"),
-
-    path("article/tags", TagListAPIView.as_view(), name="article-tags")
+    path("article/tags", TagListAPIView.as_view(), name="article-tags"),
+    path("articles/search/", searchArticlesListAPIView.as_view(), name="search_articles"),
     ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,9 +1,12 @@
+
 from rest_framework import status, generics
 
+from rest_framework import status
+from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly, AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
+from rest_framework.filters import SearchFilter
 from authors.apps import ApplicationJSONRenderer, update_data_with_user
 
 from rest_framework.exceptions import PermissionDenied, NotFound
@@ -23,6 +26,27 @@ from .models import Article, Comment, FavoriteArticle, Tag, ReportedArticles
 
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
+class searchArticlesListAPIView(ListAPIView):
+    queryset = Article.objects.all()
+    permission_classes = (AllowAny,)
+    serializer_class = ArticlesSerializer
+
+    filter_backends = [SearchFilter]
+    search_fields = ['title', 'author__username', 'tags__tag']
+
+    def get_queryset(self):
+
+        queryset = self.queryset
+        author = self.request.query_params.get('author', None)
+        if author is not None:
+            queryset = queryset.filter(author__username=author)
+        title = self.request.query_params.get('title', None)
+        if title is not None:
+            queryset = queryset.filter(title__icontains=title)
+        tag = self.request.query_params.get('tag', None)
+        if tag is not None:
+            queryset = queryset.filter(tags__tag__icontains=tag)
+        return queryset
 
 class ArticlesListAPIView(APIView):
     permission_classes = (AllowAny,)


### PR DESCRIPTION
#### What does this PR do?
- Implement searching and filtering based on parameters
#### Description of Task to be completed?
- To enable filtering based on parameters like the author, title and slug
- To enable searching of title, slug and author
#### How should this be manually tested?
- To `search`, access the endpoint `api/articles/search/` , `GET` , and search for either the title,slug or author for example `api/articles/search/?search=politics-is-shit-1`
<img width="756" alt="screen shot 2018-09-16 at 20 32 42" src="https://user-images.githubusercontent.com/30200454/45599178-bdf3e480-b9ef-11e8-9dce-f136e3d47986.png">

-  To`filter`, access the endpoint `api/articles/search/` , `GET` , and filter by either the title,slug or author for example `api/articles/search/?author=ruganda`
<img width="545" alt="screen shot 2018-09-16 at 20 38 33" src="https://user-images.githubusercontent.com/30200454/45599239-96e9e280-b9f0-11e8-8b96-9969d6b2c67e.png">
####  What are the relevant pivotal tracker stories?
 
#159951979