### PR TITLE
#160546085 Fix bugs in replies to comments

### DIFF
--- a/authors/apps/articles/helpers.py
+++ b/authors/apps/articles/helpers.py
@@ -21,6 +21,9 @@ def find_instance(model, search_key):
 def find_parent_comment(parent_comment_id):
     if parent_comment_id:
         parent_comment = find_instance(Comment, parent_comment_id)
+        if parent_comment.parent_comment is not None:
+            # This ensures that any comment made to a reply is only nested one level deep
+            parent_comment = parent_comment.parent_comment
     else:
         parent_comment = None
 


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where when users can reply to a reply.

### Description of Task to be completed?
Since we're only implementing  one-level comments, replies should only be made to comments on articles (not replies to comments).  This PR fixes that bug (when a user tries to reply to a comment that is a reply, the new comment is just made a reply to the parent comment)

### How should this be manually tested?
- Try commenting on an article using this endpoint: `POST api/article/:slug/comments`. Let's call this `comment1`
- Reply to your comment using: `POST api/article/:slug/comments/:id/reply` where `:id` is the id for `comment1`. Let this be `comment2`
- Now try replying to your reply using the same endpoint as above but using `:id` for `comment2`
- The comment will be created, but will be treated as a reply to `comment1` (since we're only implementing one-level comments)
- You can verify this by viewing the replies to `comment1` using the endpoint: `GET api/article/:slug/comments/:id/replies` where`:id` is the id for `comment1`

### What are the relevant pivotal tracker stories?
#160546085


