### PR TITLE
#159951980-implement-article-read-time

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -3,6 +3,8 @@ from django.utils.text import slugify
 
 from ..authentication.models import User
 
+import string
+
 
 class Article(models.Model):
     title = models.CharField(max_length=120)
@@ -41,6 +43,22 @@ class Article(models.Model):
             total_ratings += rate.rating
             count += 1
         return 0 if count == 0 else int(total_ratings/count)
+
+    @property
+    def read_time(self):
+        """
+        Calculates the amount of time it takes to read an article based on the number of words.
+        It assumes an average read time of 275 words per minute.
+        """
+        words = self.body
+
+        translator = str.maketrans(string.punctuation, ' '*len(string.punctuation))
+        words_list = words.translate(translator).split()
+
+        num_of_words = len(words_list)
+
+        time_to_read = round(num_of_words/275)
+        return str(time_to_read) + " min" if time_to_read > 0 else "less than 1 min"
 
     def comments_on_article(self):
         """

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -27,13 +27,13 @@ class ArticlesSerializer(GeneralRepresentation, serializers.ModelSerializer):
     class Meta:
         model = Article
         fields = ['title', 'slug', 'description', 'body',
-                  'created_at', 'updated_at', 'image', 'average_rating', 'author']
+                  'created_at', 'updated_at', 'image', 'average_rating', 'author', 'read_time']
 
 
 class ArticleSerializer(GeneralRepresentation, serializers.ModelSerializer):
     class Meta:
         model = Article
-        fields = ['title', 'description', 'body', 'author']
+        fields = ['title', 'description', 'body', 'author', 'read_time']
 
     def create(self, validated_data):
         return Article.objects.create(**validated_data)

--- a/authors/apps/articles/tests/test_articles.py
+++ b/authors/apps/articles/tests/test_articles.py
@@ -61,3 +61,16 @@ class ArticleTests(BaseTest):
     def test_out_of_range_page_number(self):
         self.paginated_response = self.client.get('/api/articles?page=999')
         self.assertEqual(self.paginated_response.status_code, status.HTTP_200_OK)
+
+    def test_article_read_time(self):
+        """Tests if an article of 275 words has a 1 minute read time"""
+        article_data = {
+            "title": "this is a long article",
+            "description": "this is a description",
+            "body": "word, "*(275*3)
+        }
+
+        create_article_response = self.client.post("/api/article/create", article_data, format="json")
+        self.assertEqual(create_article_response.status_code, status.HTTP_201_CREATED)
+        read_time = create_article_response.data['read_time']
+        self.assertEqual(read_time, "3 min")


### PR DESCRIPTION
### What does this PR do?

Calculates the read time of an article based on the number of words

### Description of task to be completed?

Have the `read_time` field as part of the response for when a user creates an article and when a user views an article.

### How should this be manually tested?

- Make a request to this endpoint: `POST /api/article/create` with article data or `GET /api/articles`.
- As part of the response, each article will have a field `read_time` that has an estimate of how long it will take to read the article.

### Any background context you want to provide?

The calculation of `read_time` is as follows: `num_of_words_in_body/275`. 275 WPM is the average reading speed of an adult, according to this article: https://blog.medium.com/read-time-and-you-bc2048ab620c.
The number of words in the body of the article are counted after removing all punctuation.

### What are the relevant pivotal tracker stories?
#159951980

### Screenshots
<img width="1098" alt="screen shot 2018-09-18 at 12 42 57" src="https://user-images.githubusercontent.com/26762336/45679055-79c42980-bb40-11e8-8057-bdcac7cef553.png">

 
