### PR TITLE
#160682173 ensure that slug is not updated on article update

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -21,6 +21,9 @@ class Article(models.Model):
         return self.title
 
     def get_unique_slug(self):
+        if self.slug:
+            return
+
         slug = slugify(self.title)
         unique_slug = slug
         num = 1

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -75,7 +75,6 @@ class ArticleSerializer(GeneralRepresentation, serializers.ModelSerializer):
 
         if validated_data["author"].id == instance.author.id:
             instance.title = validated_data.get("title", instance.title)
-            instance.slug = validated_data.get("slug", instance.get_unique_slug())
             instance.description = validated_data.get("description", instance.description)
             instance.body = validated_data.get("description", instance.description)
             instance.save()

--- a/authors/apps/articles/tests/__init__.py
+++ b/authors/apps/articles/tests/__init__.py
@@ -22,6 +22,7 @@ class BaseTest(TestCase):
             "description": "this is a description",
             "body": "this is the body"
         }
+
         self.tag_article_data = {
             "title": "the Tagging article",
             "description": "This is you",
@@ -42,11 +43,11 @@ class BaseTest(TestCase):
         }
 
         self.test_valid_ratings = {
-            "article": "this-is-my-title-1",
+            "article": "this-is-my-title",
             "rating": 3
         }
         self.test_invalid_ratings = {
-            "article": "this-is-my-title-1",
+            "article": "this-is-my-title",
             "rating": 9
         }
 
@@ -89,8 +90,8 @@ class BaseTest(TestCase):
 
         self.update_article = self.client.put("/api/article/edit/this-is-my-title", self.article_update_data,
                                               format="json")
-
-        self.delete_article = self.client.delete("/api/article/delete/this-is-the-new-title-guys", format="json")
+        # delete the duplicate
+        self.delete_article = self.client.delete("/api/article/delete/this-is-my-title-1", format="json")
 
         self.delete_article_with_no_slug = self.client.delete("/api/article/delete/", format="json")
 
@@ -100,32 +101,32 @@ class BaseTest(TestCase):
                                                            self.article_update_data,
                                                            format="json")
         self.report = {"message": "test report"}
-        self.test_article_reporting = self.client.post('/api/article/this-is-my-title-1/report', self.report,
+        self.test_article_reporting = self.client.post('/api/article/this-is-my-title/report', self.report,
                                                        format="json")
 
         self.client.credentials(HTTP_AUTHORIZATION=super_user_token)
-        self.test_article_reports_get = self.client.get('/api/article/this-is-my-title-1/report', format="json")
+        self.test_article_reports_get = self.client.get('/api/article/this-is-my-title/report', format="json")
 
         self.client.credentials(HTTP_AUTHORIZATION=self.register_second_user_response.data["token"])
 
-        self.test_article_reports_get_non_super_user = self.client.get('/api/article/this-is-my-title-1/report',
+        self.test_article_reports_get_non_super_user = self.client.get('/api/article/this-is-my-title/report',
                                                                        format="json")
 
-        self.update_article_different_owner = self.client.put("/api/article/edit/this-is-my-title-1",
+        self.update_article_different_owner = self.client.put("/api/article/edit/this-is-my-title",
                                                               self.article_update_data, format="json")
 
-        self.delete_article_different_user = self.client.delete("/api/article/delete/this-is-my-title-1",
+        self.delete_article_different_user = self.client.delete("/api/article/delete/this-is-my-title",
                                                                 format="json")
 
         self.article_like_data = {
-            "article": "this-is-my-title-1",
+            "article": "this-is-my-title",
             "like": True
         }
 
         self.test_article_liking = self.client.post("/api/article/like", self.article_like_data, format="json")
 
         self.article_dislike_data = {
-            "article": "this-is-my-title-1",
+            "article": "this-is-my-title",
             "like": False
         }
 
@@ -133,7 +134,7 @@ class BaseTest(TestCase):
 
         self.same_like_article_liking = self.client.post("/api/article/like", self.article_dislike_data, format="json")
 
-        self.update_article_different_owner = self.client.put("/api/article/edit/this-is-my-title-1",
+        self.update_article_different_owner = self.client.put("/api/article/edit/this-is-my-title",
                                                               self.article_update_data,
                                                               format="json")
 

--- a/authors/apps/articles/tests/test_article_favorite.py
+++ b/authors/apps/articles/tests/test_article_favorite.py
@@ -8,20 +8,20 @@ class ArticleTests(BaseTest):
     def favorite_article(self):
 
         return self.client.post("/api/article/favorite",
-                                                {"article": "this-is-my-title-1", "favorite": True}, format='json')
+                                                {"article": "this-is-my-title", "favorite": True}, format='json')
 
     def unfavorite_post(self):
 
         return self.client.post("/api/article/favorite",
-                                                {"article": "this-is-my-title-1", "favorite": False}, format='json')
+                                                {"article": "this-is-my-title", "favorite": False}, format='json')
 
     def unfavorite_update(self):
         return self.client.put("/api/article/favorite",
-                                                {"article": "this-is-my-title-1", "favorite": False}, format='json')
+                                                {"article": "this-is-my-title", "favorite": False}, format='json')
 
     def favorite_update(self):
         return self.client.put("/api/article/favorite",
-                               {"article": "this-is-my-title-1", "favorite": True}, format='json')
+                               {"article": "this-is-my-title", "favorite": True}, format='json')
 
     def test_favorite_article(self):
         self.assertEqual(self.favorite_article().status_code, status.HTTP_201_CREATED)
@@ -52,6 +52,6 @@ class ArticleTests(BaseTest):
 
     def test_update_before_favoriting_or_unfavoriting(self):
         response = self.client.put("/api/article/favorite",
-                         {"article": "this-is-my-title-1", "favorite": True}, format='json')
+                         {"article": "this-is-my-title", "favorite": True}, format='json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/authors/apps/articles/tests/test_article_rating.py
+++ b/authors/apps/articles/tests/test_article_rating.py
@@ -23,5 +23,5 @@ class ArticleTests(BaseTest):
         self.assertEqual(self.rate_article_again.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_average_rating(self):
-        article_instance = get_object_or_404(Article, title=self.article_data["title"])
+        article_instance = get_object_or_404(Article, title=self.article_update_data["title"])
         self.assertEqual(article_instance.average_rating, 3)

--- a/authors/apps/articles/tests/test_articles.py
+++ b/authors/apps/articles/tests/test_articles.py
@@ -6,8 +6,8 @@ from authors.apps.articles.models import Article
 
 class ArticleTests(BaseTest):
     def test_getting_article_from_model(self):
-        article_instance = get_object_or_404(Article, title=self.article_data["title"])
-        self.assertEqual(str(article_instance), self.article_data["title"])
+        article_instance = get_object_or_404(Article, title=self.article_update_data["title"])
+        self.assertEqual(str(article_instance), self.article_update_data["title"])
 
     def test_article_creation_same_title(self):
         duplicate_article_response = self.create_duplicate_article
@@ -74,10 +74,12 @@ class ArticleTests(BaseTest):
         self.assertEqual(create_article_response.status_code, status.HTTP_201_CREATED)
         read_time = create_article_response.data['read_time']
         self.assertEqual(read_time, "3 min")
+
     def test_retrieve_tags(self):
         response = self.client.get("/api/article/tags", format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('tags', response.data)
+
     def test_tag_creation(self):
         response= self.client.post("/api/article/create", self.tag_article_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/authors/apps/articles/tests/test_search.py
+++ b/authors/apps/articles/tests/test_search.py
@@ -10,9 +10,9 @@ class SearchArticleTests(BaseTest):
         self.assertIn("Jacob1234", str(response.data))
 
     def test_search_article_by_title(self):
-        response = self.client.get("/api/articles/search/?search=this is my title", format="json")
+        response = self.client.get("/api/articles/search/?search=new title", format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("this is my title", str(response.data))
+        self.assertIn("new title guys", str(response.data))
 
 
     def test_filter_article_by_author(self):
@@ -26,9 +26,9 @@ class SearchArticleTests(BaseTest):
         self.assertEqual([], response.data)
 
     def test_filter_article_by_title(self):
-        response = self.client.get("/api/articles/search/?title=this is my title", format="json")
+        response = self.client.get("/api/articles/search/?title=this is the new title guys", format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("this is my title", str(response.data))
+        self.assertIn("new title guys", str(response.data))
 
     def test_an_unauthenticated_user_can_filter_by_author(self):
         self.client = APIClient()


### PR DESCRIPTION
#### What does this PR do?
adds a check to ensure that when an article is updated the slug is not modified. and modifies test files to accommodate the change.
#### Description of Task to be completed?
- implements bug fix for article slug changing when an article is updated
- modifies tests to work with the change
#### How should this be manually tested?
update any article using its slug. use the same slug to do another update, it must be able to perform the update on that very article. 
#### What are the relevant pivotal tracker stories?
#160682173

