### PR TITLE
fix(rating): add user's rating in article response

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -16,6 +16,7 @@ class Article(models.Model):
     image = models.TextField(default=None, blank=True, null=True)
     author = models.ForeignKey(User, on_delete=models.CASCADE)
     tags = models.ManyToManyField('articles.Tag', related_name='articles')
+    user_rating = None
 
     def __str__(self):
         return self.title
@@ -77,6 +78,19 @@ class Article(models.Model):
     def dislikes(self):
         dislikes = self.like_set.filter(like=False).count()
         return dislikes
+
+    def set_user_rating(self, request):
+        try:
+            rating = self.rating_set.get(rated_by=request.user)
+        except (Rating.DoesNotExist, TypeError):
+            rating = None
+
+        if rating is not None:
+            self.user_rating = rating.rating
+
+    @property
+    def users_rating(self):
+        return self.user_rating
 
     def comments_on_article(self):
         """

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -46,7 +46,7 @@ class ArticlesSerializer(GeneralRepresentation, serializers.ModelSerializer):
         model = Article
         fields = ['title', 'slug', 'description', 'body',
                   'created_at', 'updated_at', 'image', 'average_rating', 'favorites_count', 'author', 'read_time',
-                  'likes', 'dislikes', 'tagsList']
+                  'likes', 'dislikes', 'tagsList', 'users_rating']
 
 
 class ArticleSerializer(GeneralRepresentation, serializers.ModelSerializer):

--- a/authors/apps/articles/tests/__init__.py
+++ b/authors/apps/articles/tests/__init__.py
@@ -140,8 +140,8 @@ class BaseTest(TestCase):
         # Different user rates an article
 
         self.rate_article = self.client.post('/api/article/rating/', self.test_valid_ratings, format="json")
-        self.client.credentials(HTTP_AUTHORIZATION=self.register_response.data["token"])
         self.rate_article_again = self.client.post('/api/article/rating/', self.test_valid_ratings, format="json")
+        self.get_article_after_rating = self.client.get("/api/article/get/this-is-my-title")
 
 
 class BaseTransactionTest(TransactionTestCase):

--- a/authors/apps/articles/tests/test_article_rating.py
+++ b/authors/apps/articles/tests/test_article_rating.py
@@ -25,3 +25,7 @@ class ArticleTests(BaseTest):
     def test_average_rating(self):
         article_instance = get_object_or_404(Article, title=self.article_update_data["title"])
         self.assertEqual(article_instance.average_rating, 3)
+
+    def test_user_rating_is_in_article(self):
+        self.assertIn('users_rating', self.get_article_after_rating.data)
+        self.assertEqual(self.get_article_after_rating.data["users_rating"], 3)

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -11,9 +11,7 @@ from authors.apps import ApplicationJSONRenderer, update_data_with_user
 
 from rest_framework.exceptions import PermissionDenied, NotFound, ValidationError
 
-from authors.apps.articles.serializers import (ArticlesSerializer,
-                                               ArticleSerializer,
-                                               CommentListSerializer,
+from authors.apps.articles.serializers import (ArticlesSerializer, ArticleSerializer, CommentListSerializer,
                                                CommentSerializer,
                                                RatingSerializer,
                                                LikeSerializer,
@@ -102,7 +100,9 @@ class ArticleAPIView(APIView):
 
     def get(self, request, slug):
         serializer = self.detail_serializer()
-        serializer.instance = find_instance(Article, slug)
+        article = find_instance(Article, slug)
+        article.set_user_rating(request)
+        serializer.instance = article
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def delete(self, request, slug):


### PR DESCRIPTION
### What does this PR do?
Ensures that when a `users_rating` field is part of a single article's response

### Description of task to be completed
Adding a field that helps to indicate whether a user has already rated an article, and what that rating was.

### How should this be manually tested?
- rate an article by accessing this endpoint: `/api/article/rating/`
- access the article you rated by accessing this endpoint: `/api/article/get/:slug` You should see a `users_rating` field in the response and this is the rating you gave this article.

### What are the relevant pivotal tracker stories?
[#161447339](https://www.pivotaltracker.com/story/show/161447339)
